### PR TITLE
Proximity Add-In: Skip GetCoordinates call if user enters coordinates

### DIFF
--- a/addin-proximity/app/scripts/main.js
+++ b/addin-proximity/app/scripts/main.js
@@ -161,15 +161,15 @@ geotab.addin.proximity = () => {
     }
 
     /**
-     *  Check if input are coordinates
+     *  Read input coordinates
+     *  @param {String} addressInput 
      */
-    let areCoordinates = () => {
-        var addressInput = elAddressInput.value;
+    let parseCoordinates = addressInput => {
         var addressInputArr = addressInput.split(',');
-        if(addressInputArr.length === 2 && parseFloat(addressInputArr[0]) && parseFloat(addressInputArr[1])){
+        if (addressInputArr.length === 2 && parseFloat(addressInputArr[0]) && parseFloat(addressInputArr[1])) {
             return [{x:parseFloat(addressInputArr[1]),y:parseFloat(addressInputArr[0])}];
-        }else{
-            return false;
+        } else {
+            return [];
         }
     }
     
@@ -341,10 +341,10 @@ geotab.addin.proximity = () => {
             toggleLoading(false);
         }
 
-        let inputCoordinates = areCoordinates();
-        if(inputCoordinates){
+        let inputCoordinates = parseCoordinates(elAddressInput.value);
+        if (inputCoordinates.length) {
             calculateAndRender(inputCoordinates);
-        }else{
+        } else {
             api.call('GetCoordinates', {
                 addresses: [elAddressInput.value]
             }, async (result) => {

--- a/addin-proximity/app/scripts/main.js
+++ b/addin-proximity/app/scripts/main.js
@@ -159,6 +159,19 @@ geotab.addin.proximity = () => {
             }, 0);
         }
     }
+
+    /**
+     *  Check if input are coordinates
+     */
+    let areCoordinates = () => {
+        var addressInput = elAddressInput.value;
+        var addressInputArr = addressInput.split(',');
+        if(addressInputArr.length === 2 && parseFloat(addressInputArr[0]) && parseFloat(addressInputArr[1])){
+            return [{x:parseFloat(addressInputArr[1]),y:parseFloat(addressInputArr[0])}];
+        }else{
+            return false;
+        }
+    }
     
     /**
      *  Calculates and renders proximity from inputs
@@ -186,9 +199,7 @@ geotab.addin.proximity = () => {
         clearMap();
         toggleLoading(true);
 
-        api.call('GetCoordinates', {
-            addresses: [elAddressInput.value]
-        }, async (result) => {
+        let calculateAndRender = async (result) => {
             if (!result || result.length < 1 || !result[0]) {
                 logger('Could not find the address');
                 toggleLoading(false);
@@ -328,10 +339,21 @@ geotab.addin.proximity = () => {
             }
             elExport.disabled = false;
             toggleLoading(false);
-        }, error => {
-            logger(error);
-            toggleLoading(false);
-        });
+        }
+
+        let inputCoordinates = areCoordinates();
+        if(inputCoordinates){
+            calculateAndRender(inputCoordinates);
+        }else{
+            api.call('GetCoordinates', {
+                addresses: [elAddressInput.value]
+            }, async (result) => {
+                calculateAndRender(result);
+            }, error => {
+                logger(error);
+                toggleLoading(false);
+            });
+        }
     };
 
     /**


### PR DESCRIPTION
Proximity Add-In: Check if the address input are coordinates, and skip the GetCoordinates call if they are. 