### PR TITLE
Fix DST offset

### DIFF
--- a/addin-proximity/app/scripts/main.js
+++ b/addin-proximity/app/scripts/main.js
@@ -182,9 +182,9 @@ geotab.addin.proximity = () => {
         clearMap();
 
         let dateFrom = new Date(elDateFromInput.value + ':00Z');
-        let utcFrom = new Date(dateFrom.setMinutes(dateFrom.getMinutes() + new Date().getTimezoneOffset())).toISOString();
+        let utcFrom = new Date(dateFrom.setMinutes(dateFrom.getMinutes() + dateFrom.getTimezoneOffset())).toISOString();
         let dateTo = new Date(elDateToInput.value + ':00Z');
-        let utcTo = new Date(dateTo.setMinutes(dateTo.getMinutes() + new Date().getTimezoneOffset())).toISOString();
+        let utcTo = new Date(dateTo.setMinutes(dateTo.getMinutes() + dateTo.getTimezoneOffset())).toISOString();
 
         toggleLoading(true);
 


### PR DESCRIPTION
Previously it used today's UTC offset to convert input date-times to UTC, but following DST change, if I now enter a date prior to DST change, UTC offset is not the same. This fixes that by using the supplied date's UTC offset, and not forcing it to use today's.